### PR TITLE
add appveyor and codacy badges

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -7,6 +7,8 @@ ifdef::env-github,env-browser[:relfileprefix: docs/]
 
 https://github.com/AY1920S2-CS2103T-W16-3/main[image:https://travis-ci.org/AY1920S2-CS2103T-W16-3/main.svg?branch=master[Build Status]]
 https://coveralls.io/github/AY1920S2-CS2103T-W16-3/main?branch=master[image:https://coveralls.io/repos/github/AY1920S2-CS2103T-W16-3/main/badge.svg?branch=master[Coverage Status]]
+https://ci.appveyor.com/project/teikjun/main-obe5y/branch/master[image:https://ci.appveyor.com/api/projects/status/01kv1ged83vovfi3/branch/master?svg=true[Build status]]
+https://https://www.codacy.com/gh/AY1920S2-CS2103T-W16-3/main?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=AY1920S2-CS2103T-W16-3/main&amp;utm_campaign=Badge_Grade[image:https://api.codacy.com/project/badge/Grade/8ff09067ff534489afad2264bade805a[Codacy Badge]]
 
 ifdef::env-github[]
 image::docs/images/Ui.png[width="600"]


### PR DESCRIPTION
Appveyor - checks if it works on windows machines (as opposed to Travis, which is for unix machines)
Codacy - check for coding standard violations